### PR TITLE
Decouple queued patients from specific rooms

### DIFF
--- a/api/src/main/java/org/openmrs/module/queue/api/QueueRoomService.java
+++ b/api/src/main/java/org/openmrs/module/queue/api/QueueRoomService.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.openmrs.Location;
+import org.openmrs.api.APIException;
 import org.openmrs.module.queue.model.Queue;
 import org.openmrs.module.queue.model.QueueRoom;
 
@@ -27,4 +28,8 @@ public interface QueueRoomService {
 	QueueRoom createQueueRoom(@NotNull QueueRoom queueRoom);
 	
 	List<QueueRoom> getQueueRoomsByServiceAndLocation(Queue queue, Location location);
+
+	void voidQueueRoom(@NotNull String queueRoomUuid, String voidReason);
+
+	void purgeQueueRoom(QueueRoom queueRoom) throws APIException;
 }

--- a/api/src/main/java/org/openmrs/module/queue/api/QueueRoomService.java
+++ b/api/src/main/java/org/openmrs/module/queue/api/QueueRoomService.java
@@ -11,10 +11,11 @@ package org.openmrs.module.queue.api;
 
 import javax.validation.constraints.NotNull;
 
-import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
-import org.openmrs.Concept;
+import org.openmrs.Location;
+import org.openmrs.module.queue.model.Queue;
 import org.openmrs.module.queue.model.QueueRoom;
 
 public interface QueueRoomService {
@@ -25,5 +26,5 @@ public interface QueueRoomService {
 	
 	QueueRoom createQueueRoom(@NotNull QueueRoom queueRoom);
 	
-	Collection<QueueRoom> getQueueRoomsByQueue(@NotNull Concept concept);
+	List<QueueRoom> getQueueRoomsByServiceAndLocation(Queue queue, Location location);
 }

--- a/api/src/main/java/org/openmrs/module/queue/api/QueueRoomService.java
+++ b/api/src/main/java/org/openmrs/module/queue/api/QueueRoomService.java
@@ -1,0 +1,29 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.queue.api;
+
+import javax.validation.constraints.NotNull;
+
+import java.util.Collection;
+import java.util.Optional;
+
+import org.openmrs.Concept;
+import org.openmrs.module.queue.model.QueueRoom;
+
+public interface QueueRoomService {
+	
+	Optional<QueueRoom> getQueueRoomByUuid(@NotNull String uuid);
+	
+	Optional<QueueRoom> getQueueRoomById(@NotNull int id);
+	
+	QueueRoom createQueueRoom(@NotNull QueueRoom queueRoom);
+	
+	Collection<QueueRoom> getQueueRoomsByQueue(@NotNull Concept concept);
+}

--- a/api/src/main/java/org/openmrs/module/queue/api/RoomProviderMapService.java
+++ b/api/src/main/java/org/openmrs/module/queue/api/RoomProviderMapService.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.openmrs.Provider;
+import org.openmrs.api.APIException;
 import org.openmrs.module.queue.model.QueueRoom;
 import org.openmrs.module.queue.model.RoomProviderMap;
 
@@ -27,5 +28,9 @@ public interface RoomProviderMapService {
 	RoomProviderMap createRoomProviderMap(@NotNull RoomProviderMap roomProviderMap);
 	
 	List<RoomProviderMap> getRoomProvider(Provider provider, QueueRoom queueRoom);
+
+	void voidRoomProviderMap(@NotNull String roomProviderMapUuid, String voidReason);
+
+	void purgeRoomProviderMap(RoomProviderMap roomProviderMap) throws APIException;
 	
 }

--- a/api/src/main/java/org/openmrs/module/queue/api/RoomProviderMapService.java
+++ b/api/src/main/java/org/openmrs/module/queue/api/RoomProviderMapService.java
@@ -1,0 +1,31 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.queue.api;
+
+import javax.validation.constraints.NotNull;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.openmrs.Provider;
+import org.openmrs.module.queue.model.QueueRoom;
+import org.openmrs.module.queue.model.RoomProviderMap;
+
+public interface RoomProviderMapService {
+	
+	Optional<RoomProviderMap> getRoomProviderMapByUuid(@NotNull String uuid);
+	
+	Optional<RoomProviderMap> getRoomProviderMapById(@NotNull int id);
+	
+	RoomProviderMap createRoomProviderMap(@NotNull RoomProviderMap roomProviderMap);
+	
+	List<RoomProviderMap> getRoomProvider(Provider provider, QueueRoom queueRoom);
+	
+}

--- a/api/src/main/java/org/openmrs/module/queue/api/dao/QueueRoomDao.java
+++ b/api/src/main/java/org/openmrs/module/queue/api/dao/QueueRoomDao.java
@@ -1,0 +1,23 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.queue.api.dao;
+
+import javax.validation.constraints.NotNull;
+
+import java.util.Collection;
+
+import org.openmrs.Concept;
+import org.openmrs.module.queue.model.QueueRoom;
+
+public interface QueueRoomDao extends BaseQueueDao<QueueRoom> {
+	
+	Collection<QueueRoom> getQueueRoomsByQueue(@NotNull Concept concept);
+	
+}

--- a/api/src/main/java/org/openmrs/module/queue/api/dao/QueueRoomDao.java
+++ b/api/src/main/java/org/openmrs/module/queue/api/dao/QueueRoomDao.java
@@ -9,15 +9,13 @@
  */
 package org.openmrs.module.queue.api.dao;
 
-import javax.validation.constraints.NotNull;
+import java.util.List;
 
-import java.util.Collection;
-
-import org.openmrs.Concept;
+import org.openmrs.Location;
+import org.openmrs.module.queue.model.Queue;
 import org.openmrs.module.queue.model.QueueRoom;
 
 public interface QueueRoomDao extends BaseQueueDao<QueueRoom> {
 	
-	Collection<QueueRoom> getQueueRoomsByQueue(@NotNull Concept concept);
-	
+	List<QueueRoom> getQueueRoomsByServiceAndLocation(Queue queue, Location location);
 }

--- a/api/src/main/java/org/openmrs/module/queue/api/dao/RoomProviderMapDao.java
+++ b/api/src/main/java/org/openmrs/module/queue/api/dao/RoomProviderMapDao.java
@@ -1,0 +1,22 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.queue.api.dao;
+
+import java.util.List;
+
+import org.openmrs.Provider;
+import org.openmrs.module.queue.model.QueueRoom;
+import org.openmrs.module.queue.model.RoomProviderMap;
+
+public interface RoomProviderMapDao extends BaseQueueDao<RoomProviderMap> {
+	
+	List<RoomProviderMap> getRoomProvider(Provider provider, QueueRoom queueRoom);
+	
+}

--- a/api/src/main/java/org/openmrs/module/queue/api/dao/impl/QueueRoomDaoImpl.java
+++ b/api/src/main/java/org/openmrs/module/queue/api/dao/impl/QueueRoomDaoImpl.java
@@ -9,11 +9,14 @@
  */
 package org.openmrs.module.queue.api.dao.impl;
 
-import java.util.Collection;
+import java.util.List;
 
+import org.hibernate.Query;
 import org.hibernate.SessionFactory;
-import org.openmrs.Concept;
+import org.openmrs.Location;
+import org.openmrs.api.APIException;
 import org.openmrs.module.queue.api.dao.QueueRoomDao;
+import org.openmrs.module.queue.model.Queue;
 import org.openmrs.module.queue.model.QueueRoom;
 import org.springframework.beans.factory.annotation.Qualifier;
 
@@ -24,8 +27,27 @@ public class QueueRoomDaoImpl extends AbstractBaseQueueDaoImpl<QueueRoom> implem
 	}
 	
 	@Override
-	public Collection<QueueRoom> getQueueRoomsByQueue(Concept concept) {
-		return null;
+	public List<QueueRoom> getQueueRoomsByServiceAndLocation(Queue queue, Location location) {
+		if (queue == null && location == null) {
+			throw new APIException("Both Queue and Location cannot be null");
+		}
+		String stringQuery = "Select queueRoom from QueueRoom as queueRoom WHERE retired = 0 ";
+		if (queue != null) {
+			stringQuery += "AND queueRoom.queue = :queue ";
+		}
+		if (location != null) {
+			stringQuery += "AND queueRoom.queue.location = :location ";
+		}
+		
+		Query query = super.getSessionFactory().getCurrentSession().createQuery(stringQuery);
+		if (queue != null) {
+			query.setParameter("queue", queue);
+		}
+		if (location != null) {
+			query.setParameter("location", location);
+		}
+		
+		return query.list();
 	}
 	
 }

--- a/api/src/main/java/org/openmrs/module/queue/api/dao/impl/QueueRoomDaoImpl.java
+++ b/api/src/main/java/org/openmrs/module/queue/api/dao/impl/QueueRoomDaoImpl.java
@@ -1,0 +1,31 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.queue.api.dao.impl;
+
+import java.util.Collection;
+
+import org.hibernate.SessionFactory;
+import org.openmrs.Concept;
+import org.openmrs.module.queue.api.dao.QueueRoomDao;
+import org.openmrs.module.queue.model.QueueRoom;
+import org.springframework.beans.factory.annotation.Qualifier;
+
+public class QueueRoomDaoImpl extends AbstractBaseQueueDaoImpl<QueueRoom> implements QueueRoomDao {
+	
+	public QueueRoomDaoImpl(@Qualifier("sessionFactory") SessionFactory sessionFactory) {
+		super(sessionFactory);
+	}
+	
+	@Override
+	public Collection<QueueRoom> getQueueRoomsByQueue(Concept concept) {
+		return null;
+	}
+	
+}

--- a/api/src/main/java/org/openmrs/module/queue/api/dao/impl/RoomProviderMapDaoImpl.java
+++ b/api/src/main/java/org/openmrs/module/queue/api/dao/impl/RoomProviderMapDaoImpl.java
@@ -32,10 +32,11 @@ public class RoomProviderMapDaoImpl extends AbstractBaseQueueDaoImpl<RoomProvide
 			throw new APIException("Both QueueRoom and Provider cannot be null");
 		}
 		String stringQuery = "Select roomProviderMap from RoomProviderMap as roomProviderMap WHERE voided = 0 ";
-		if (provider != null) {
+		if (provider != null && queueRoom != null) {
+			stringQuery += "AND ( roomProviderMap.provider = :provider or roomProviderMap.queueRoom = :queueRoom ) ";
+		} else if (provider != null) {
 			stringQuery += "AND roomProviderMap.provider = :provider ";
-		}
-		if (queueRoom != null) {
+		} else if (queueRoom != null) {
 			stringQuery += "AND roomProviderMap.queueRoom = :queueRoom ";
 		}
 		

--- a/api/src/main/java/org/openmrs/module/queue/api/dao/impl/RoomProviderMapDaoImpl.java
+++ b/api/src/main/java/org/openmrs/module/queue/api/dao/impl/RoomProviderMapDaoImpl.java
@@ -1,0 +1,52 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.queue.api.dao.impl;
+
+import java.util.List;
+
+import org.hibernate.Query;
+import org.hibernate.SessionFactory;
+import org.openmrs.Provider;
+import org.openmrs.api.APIException;
+import org.openmrs.module.queue.api.dao.RoomProviderMapDao;
+import org.openmrs.module.queue.model.QueueRoom;
+import org.openmrs.module.queue.model.RoomProviderMap;
+import org.springframework.beans.factory.annotation.Qualifier;
+
+public class RoomProviderMapDaoImpl extends AbstractBaseQueueDaoImpl<RoomProviderMap> implements RoomProviderMapDao {
+	
+	public RoomProviderMapDaoImpl(@Qualifier("sessionFactory") SessionFactory sessionFactory) {
+		super(sessionFactory);
+	}
+	
+	@Override
+	public List<RoomProviderMap> getRoomProvider(Provider provider, QueueRoom queueRoom) {
+		if (provider == null && queueRoom == null) {
+			throw new APIException("Both QueueRoom and Provider cannot be null");
+		}
+		String stringQuery = "Select roomProviderMap from RoomProviderMap as roomProviderMap WHERE voided = 0 ";
+		if (provider != null) {
+			stringQuery += "AND roomProviderMap.provider = :provider ";
+		}
+		if (queueRoom != null) {
+			stringQuery += "AND roomProviderMap.queueRoom = :queueRoom ";
+		}
+		
+		Query query = super.getSessionFactory().getCurrentSession().createQuery(stringQuery);
+		if (provider != null) {
+			query.setParameter("provider", provider);
+		}
+		if (queueRoom != null) {
+			query.setParameter("queueRoom", queueRoom);
+		}
+		
+		return query.list();
+	}
+}

--- a/api/src/main/java/org/openmrs/module/queue/api/impl/QueueRoomServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/queue/api/impl/QueueRoomServiceImpl.java
@@ -9,6 +9,7 @@
  */
 package org.openmrs.module.queue.api.impl;
 
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 
@@ -16,12 +17,16 @@ import lombok.AccessLevel;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.openmrs.Location;
+import org.openmrs.api.APIException;
+import org.openmrs.api.context.Context;
 import org.openmrs.api.impl.BaseOpenmrsService;
 import org.openmrs.module.queue.api.QueueRoomService;
 import org.openmrs.module.queue.api.dao.QueueRoomDao;
 import org.openmrs.module.queue.model.Queue;
 import org.openmrs.module.queue.model.QueueRoom;
 import org.springframework.transaction.annotation.Transactional;
+
+import javax.validation.constraints.NotNull;
 
 @Slf4j
 @Transactional
@@ -53,5 +58,20 @@ public class QueueRoomServiceImpl extends BaseOpenmrsService implements QueueRoo
 	public List<QueueRoom> getQueueRoomsByServiceAndLocation(Queue queue, Location location) {
 		return this.dao.getQueueRoomsByServiceAndLocation(queue, location);
 	}
-	
+
+	@Override
+	public void voidQueueRoom(@NotNull String queueRoomUuid, String voidReason) {
+		this.dao.get(queueRoomUuid).ifPresent(queueRoom -> {
+			queueRoom.setRetired(true);
+			queueRoom.setDateRetired(new Date());
+			queueRoom.setRetireReason(voidReason);
+			queueRoom.setRetiredBy(Context.getAuthenticatedUser());
+			this.dao.createOrUpdate(queueRoom);
+		});
+	}
+
+	@Override
+	public void purgeQueueRoom(QueueRoom queueRoom) throws APIException {
+		this.dao.delete(queueRoom);
+	}
 }

--- a/api/src/main/java/org/openmrs/module/queue/api/impl/QueueRoomServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/queue/api/impl/QueueRoomServiceImpl.java
@@ -1,0 +1,56 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.queue.api.impl;
+
+import java.util.Collection;
+import java.util.Optional;
+
+import lombok.AccessLevel;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.openmrs.Concept;
+import org.openmrs.api.impl.BaseOpenmrsService;
+import org.openmrs.module.queue.api.QueueRoomService;
+import org.openmrs.module.queue.api.dao.QueueRoomDao;
+import org.openmrs.module.queue.model.QueueRoom;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Transactional
+@Setter(AccessLevel.MODULE)
+public class QueueRoomServiceImpl extends BaseOpenmrsService implements QueueRoomService {
+	
+	private QueueRoomDao dao;
+	
+	public void setDao(QueueRoomDao dao) {
+		this.dao = dao;
+	}
+	
+	@Override
+	public Optional<QueueRoom> getQueueRoomByUuid(String uuid) {
+		return this.dao.get(uuid);
+	}
+	
+	@Override
+	public Optional<QueueRoom> getQueueRoomById(int id) {
+		return this.dao.get(id);
+	}
+	
+	@Override
+	public QueueRoom createQueueRoom(QueueRoom queueRoom) {
+		return this.dao.createOrUpdate(queueRoom);
+	}
+	
+	@Override
+	public Collection<QueueRoom> getQueueRoomsByQueue(Concept concept) {
+		return null;
+	}
+	
+}

--- a/api/src/main/java/org/openmrs/module/queue/api/impl/QueueRoomServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/queue/api/impl/QueueRoomServiceImpl.java
@@ -9,16 +9,17 @@
  */
 package org.openmrs.module.queue.api.impl;
 
-import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 import lombok.AccessLevel;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
-import org.openmrs.Concept;
+import org.openmrs.Location;
 import org.openmrs.api.impl.BaseOpenmrsService;
 import org.openmrs.module.queue.api.QueueRoomService;
 import org.openmrs.module.queue.api.dao.QueueRoomDao;
+import org.openmrs.module.queue.model.Queue;
 import org.openmrs.module.queue.model.QueueRoom;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -49,8 +50,8 @@ public class QueueRoomServiceImpl extends BaseOpenmrsService implements QueueRoo
 	}
 	
 	@Override
-	public Collection<QueueRoom> getQueueRoomsByQueue(Concept concept) {
-		return null;
+	public List<QueueRoom> getQueueRoomsByServiceAndLocation(Queue queue, Location location) {
+		return this.dao.getQueueRoomsByServiceAndLocation(queue, location);
 	}
 	
 }

--- a/api/src/main/java/org/openmrs/module/queue/api/impl/RoomProviderMapServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/queue/api/impl/RoomProviderMapServiceImpl.java
@@ -1,0 +1,57 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.queue.api.impl;
+
+import java.util.List;
+import java.util.Optional;
+
+import lombok.AccessLevel;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.openmrs.Provider;
+import org.openmrs.api.impl.BaseOpenmrsService;
+import org.openmrs.module.queue.api.RoomProviderMapService;
+import org.openmrs.module.queue.api.dao.RoomProviderMapDao;
+import org.openmrs.module.queue.model.QueueRoom;
+import org.openmrs.module.queue.model.RoomProviderMap;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Transactional
+@Setter(AccessLevel.MODULE)
+public class RoomProviderMapServiceImpl extends BaseOpenmrsService implements RoomProviderMapService {
+	
+	private RoomProviderMapDao dao;
+	
+	public void setDao(RoomProviderMapDao dao) {
+		this.dao = dao;
+	}
+	
+	@Override
+	public Optional<RoomProviderMap> getRoomProviderMapByUuid(String uuid) {
+		return this.dao.get(uuid);
+	}
+	
+	@Override
+	public Optional<RoomProviderMap> getRoomProviderMapById(int id) {
+		return this.dao.get(id);
+	}
+	
+	@Override
+	public RoomProviderMap createRoomProviderMap(RoomProviderMap roomProviderMap) {
+		return this.dao.createOrUpdate(roomProviderMap);
+	}
+	
+	@Override
+	public List<RoomProviderMap> getRoomProvider(Provider provider, QueueRoom queueRoom) {
+		return this.dao.getRoomProvider(provider, queueRoom);
+	}
+	
+}

--- a/api/src/main/java/org/openmrs/module/queue/api/impl/RoomProviderMapServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/queue/api/impl/RoomProviderMapServiceImpl.java
@@ -9,6 +9,7 @@
  */
 package org.openmrs.module.queue.api.impl;
 
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 
@@ -16,6 +17,8 @@ import lombok.AccessLevel;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.openmrs.Provider;
+import org.openmrs.api.APIException;
+import org.openmrs.api.context.Context;
 import org.openmrs.api.impl.BaseOpenmrsService;
 import org.openmrs.module.queue.api.RoomProviderMapService;
 import org.openmrs.module.queue.api.dao.RoomProviderMapDao;
@@ -53,5 +56,20 @@ public class RoomProviderMapServiceImpl extends BaseOpenmrsService implements Ro
 	public List<RoomProviderMap> getRoomProvider(Provider provider, QueueRoom queueRoom) {
 		return this.dao.getRoomProvider(provider, queueRoom);
 	}
-	
+
+	@Override
+	public void voidRoomProviderMap(String roomProviderMapUuid, String voidReason) {
+		this.dao.get(roomProviderMapUuid).ifPresent(obj -> {
+			obj.setVoided(true);
+			obj.setDateVoided(new Date());
+			obj.setVoidReason(voidReason);
+			obj.setVoidedBy(Context.getAuthenticatedUser());
+			this.dao.createOrUpdate(obj);
+		});
+	}
+
+	@Override
+	public void purgeRoomProviderMap(RoomProviderMap roomProviderMap) throws APIException {
+		this.dao.delete(roomProviderMap);
+	}
 }

--- a/api/src/main/java/org/openmrs/module/queue/api/impl/RoomProviderMapServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/queue/api/impl/RoomProviderMapServiceImpl.java
@@ -49,6 +49,14 @@ public class RoomProviderMapServiceImpl extends BaseOpenmrsService implements Ro
 	
 	@Override
 	public RoomProviderMap createRoomProviderMap(RoomProviderMap roomProviderMap) {
+		if (roomProviderMap.getId() == null) {
+			List<RoomProviderMap> existingAssignedRooms = getRoomProvider(roomProviderMap.getProvider(),
+			    roomProviderMap.getQueueRoom());
+			existingAssignedRooms.forEach(roomProviderMap1 -> voidRoomProviderMap(roomProviderMap1.getUuid(), "Api call"));
+			
+			return this.dao.createOrUpdate(roomProviderMap);
+		}
+		roomProviderMap.setDateChanged(new Date());
 		return this.dao.createOrUpdate(roomProviderMap);
 	}
 	

--- a/api/src/main/java/org/openmrs/module/queue/model/Queue.java
+++ b/api/src/main/java/org/openmrs/module/queue/model/Queue.java
@@ -55,7 +55,7 @@ public class Queue extends BaseChangeableOpenmrsMetadata {
 	@Where(clause = "voided = 0 and (started_at <= current_timestamp() and ended_at is null)")
 	private List<QueueEntry> queueEntries;
 	
-	@OneToMany(mappedBy = "queue", cascade = CascadeType.ALL, fetch = FetchType.EAGER)
+	@OneToMany(mappedBy = "queue", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
 	@Where(clause = "retired = 0")
 	private List<QueueRoom> queueRooms;
 	

--- a/api/src/main/java/org/openmrs/module/queue/model/QueueRoom.java
+++ b/api/src/main/java/org/openmrs/module/queue/model/QueueRoom.java
@@ -9,63 +9,47 @@
  */
 package org.openmrs.module.queue.model;
 
-import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
 import javax.persistence.Table;
 
-import java.util.List;
-
-import lombok.Data;
 import lombok.EqualsAndHashCode;
-import org.hibernate.annotations.Where;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.openmrs.BaseChangeableOpenmrsMetadata;
-import org.openmrs.Concept;
-import org.openmrs.Location;
 
 @EqualsAndHashCode(callSuper = true)
-@Data
+@NoArgsConstructor
+@Setter
+@Getter
 @Entity
-@Table(name = "queue")
-public class Queue extends BaseChangeableOpenmrsMetadata {
+@Table(name = "queue_room")
+public class QueueRoom extends BaseChangeableOpenmrsMetadata {
 	
 	private static final long serialVersionUID = 1L;
 	
 	@Id
 	@GeneratedValue(strategy = GenerationType.AUTO)
-	@Column(name = "queue_id")
-	private Integer queueId;
+	@Column(name = "queue_room_id")
+	private Integer queueRoom;
 	
 	@ManyToOne
-	@JoinColumn(name = "location_id", nullable = false)
-	private Location location;
-	
-	@ManyToOne
-	@JoinColumn(name = "service", referencedColumnName = "concept_id", nullable = false)
-	private Concept service;
-	
-	@OneToMany(mappedBy = "queue", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
-	@Where(clause = "voided = 0 and (started_at <= current_timestamp() and ended_at is null)")
-	private List<QueueEntry> queueEntries;
-	
-	@OneToMany(mappedBy = "queue", cascade = CascadeType.ALL, fetch = FetchType.EAGER)
-	@Where(clause = "retired = 0")
-	private List<QueueRoom> queueRooms;
+	@JoinColumn(name = "queue_id", nullable = false)
+	private Queue queue;
 	
 	@Override
 	public Integer getId() {
-		return getQueueId();
+		return getQueueRoom();
 	}
 	
 	@Override
-	public void setId(Integer id) {
-		this.setQueueId(id);
+	public void setId(Integer integer) {
+		setQueueRoom(integer);
 	}
 }

--- a/api/src/main/java/org/openmrs/module/queue/model/RoomProviderMap.java
+++ b/api/src/main/java/org/openmrs/module/queue/model/RoomProviderMap.java
@@ -1,0 +1,60 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.queue.model;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.openmrs.BaseOpenmrsData;
+import org.openmrs.Provider;
+
+@EqualsAndHashCode(callSuper = true)
+@NoArgsConstructor
+@Setter
+@Getter
+@Entity
+@Table(name = "room_provider_map")
+public class RoomProviderMap extends BaseOpenmrsData {
+	
+	private static final long serialVersionUID = 1L;
+	
+	@Id
+	@GeneratedValue(strategy = GenerationType.AUTO)
+	@Column(name = "room_provider_map_id")
+	private Integer roomProviderMapId;
+	
+	@ManyToOne
+	@JoinColumn(name = "queue_room_id", nullable = false)
+	private QueueRoom queueRoom;
+	
+	@ManyToOne
+	@JoinColumn(name = "provider_id", nullable = false)
+	private Provider provider;
+	
+	@Override
+	public Integer getId() {
+		return getRoomProviderMapId();
+	}
+	
+	@Override
+	public void setId(Integer integer) {
+		setRoomProviderMapId(integer);
+	}
+}

--- a/api/src/main/java/org/openmrs/module/queue/validators/QueueRoomValidation.java
+++ b/api/src/main/java/org/openmrs/module/queue/validators/QueueRoomValidation.java
@@ -1,0 +1,41 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.queue.validators;
+
+import lombok.extern.slf4j.Slf4j;
+import org.openmrs.annotation.Handler;
+import org.openmrs.module.queue.model.QueueRoom;
+import org.springframework.validation.Errors;
+import org.springframework.validation.ValidationUtils;
+import org.springframework.validation.Validator;
+
+@Slf4j
+@Handler(supports = { QueueRoom.class }, order = 50)
+public class QueueRoomValidation implements Validator {
+	
+	@Override
+	public boolean supports(Class<?> aClass) {
+		return QueueRoom.class.isAssignableFrom(aClass);
+	}
+	
+	@Override
+	public void validate(Object obj, Errors errors) {
+		log.debug("{}.validate", this.getClass().getName());
+		//instanceof checks for null
+		if (!(obj instanceof QueueRoom)) {
+			throw new IllegalArgumentException(
+			        "The parameter target should not be null & must be of type" + QueueRoom.class);
+		}
+		QueueRoom queueRoom = (QueueRoom) obj;
+		ValidationUtils.rejectIfEmptyOrWhitespace(errors, "name", "queueRoom.name.null", "QueueRoom name can't be null");
+		ValidationUtils.rejectIfEmptyOrWhitespace(errors, "queue", "queueRoom.queue.null",
+		    "Queue in QueueRoom can't be null");
+	}
+}

--- a/api/src/main/java/org/openmrs/module/queue/validators/RoomProviderMapValidator.java
+++ b/api/src/main/java/org/openmrs/module/queue/validators/RoomProviderMapValidator.java
@@ -1,0 +1,42 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.queue.validators;
+
+import lombok.extern.slf4j.Slf4j;
+import org.openmrs.annotation.Handler;
+import org.openmrs.module.queue.model.RoomProviderMap;
+import org.springframework.validation.Errors;
+import org.springframework.validation.ValidationUtils;
+import org.springframework.validation.Validator;
+
+@Slf4j
+@Handler(supports = { RoomProviderMap.class }, order = 50)
+public class RoomProviderMapValidator implements Validator {
+	
+	@Override
+	public boolean supports(Class<?> aClass) {
+		return RoomProviderMap.class.isAssignableFrom(aClass);
+	}
+	
+	@Override
+	public void validate(Object obj, Errors errors) {
+		log.debug("{}.validate", this.getClass().getName());
+		//instanceof checks for null
+		if (!(obj instanceof RoomProviderMap)) {
+			throw new IllegalArgumentException(
+			        "The parameter target should not be null & must be of type" + RoomProviderMap.class);
+		}
+		RoomProviderMap roomProviderMap = (RoomProviderMap) obj;
+		ValidationUtils.rejectIfEmptyOrWhitespace(errors, "queueRoom", "roomProviderMap.queueRoom.null",
+		    "QueueRoom in RoomProviderMap can't be null");
+		ValidationUtils.rejectIfEmptyOrWhitespace(errors, "provider", "roomProviderMap.provider.null",
+		    "Provider in RoomProviderMap can't be null");
+	}
+}

--- a/api/src/main/resources/liquibase.xml
+++ b/api/src/main/resources/liquibase.xml
@@ -262,4 +262,55 @@
                                  referencedTableName="queue" referencedColumnNames="queue_id"/>
     </changeSet>
 
+    <changeSet id="add_room_provider_map_20230222" author="jecihjoy">
+        <preConditions onError="WARN" onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="room_provider_map"/>
+            </not>
+        </preConditions>
+        <createTable tableName="room_provider_map">
+            <column name="room_provider_map_id" type="int" autoIncrement="true">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="queue_room_id" type="int">
+                <constraints nullable="false"/>
+            </column>
+            <column name="provider_id" type="int">
+                <constraints nullable="false"/>
+            </column>
+            <column name="creator" type="int">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column name="changed_by" type="int"/>
+            <column name="date_changed" type="datetime"/>
+            <column name="voided" type="boolean" defaultValueBoolean="false">
+                <constraints nullable="false"/>
+            </column>
+            <column name="voided_by" type="int"/>
+            <column name="date_voided" type="datetime"/>
+            <column name="void_reason" type="varchar(255)"/>
+            <column name="uuid" type="char(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+        </createTable>
+        <addForeignKeyConstraint constraintName="room_provider_map_creator_fk"
+                                 baseTableName="room_provider_map" baseColumnNames="creator"
+                                 referencedTableName="users" referencedColumnNames="user_id"/>
+        <addForeignKeyConstraint constraintName="room_provider_map_changed_by_fk"
+                                 baseTableName="room_provider_map" baseColumnNames="changed_by"
+                                 referencedTableName="users" referencedColumnNames="user_id"/>
+        <addForeignKeyConstraint constraintName="room_provider_map_voided_by_fk"
+                                 baseTableName="room_provider_map" baseColumnNames="voided_by"
+                                 referencedTableName="users" referencedColumnNames="user_id"/>
+        <addForeignKeyConstraint baseTableName="room_provider_map" baseColumnNames="queue_room_id"
+                                 constraintName="room_provider_map_queue_room_fk" referencedTableName="queue_room"
+                                 referencedColumnNames="queue_room_id"/>
+        <addForeignKeyConstraint baseTableName="room_provider_map" baseColumnNames="provider_id"
+                                 constraintName="room_provider_map_provider_id_fk" referencedTableName="provider"
+                                 referencedColumnNames="provider_id"/>
+    </changeSet>
+
 </databaseChangeLog>

--- a/api/src/main/resources/liquibase.xml
+++ b/api/src/main/resources/liquibase.xml
@@ -212,5 +212,54 @@
             uuid());
         </sql>
     </changeSet>
+    
+    <changeSet id="add_queue_room_20230221" author="jecihjoy">
+        <preConditions onError="WARN" onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="queue_room"/>
+            </not>
+        </preConditions>
+        <createTable tableName="queue_room">
+            <column name="queue_room_id" type="int" autoIncrement="true">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="queue_id" type="int">
+                <constraints nullable="false"/>
+            </column>
+            <column name="name" type="varchar(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="description" type="varchar(255)"/>
+            <column name="creator" type="int">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column name="changed_by" type="int"/>
+            <column name="date_changed" type="datetime"/>
+            <column name="retired" type="boolean" defaultValueBoolean="false">
+                <constraints nullable="false"/>
+            </column>
+            <column name="retired_by" type="int"/>
+            <column name="date_retired" type="datetime"/>
+            <column name="retire_reason" type="varchar(255)"/>
+            <column name="uuid" type="char(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+        </createTable>
+        <addForeignKeyConstraint constraintName="queue_room_creator_fk"
+                                 baseTableName="queue_room" baseColumnNames="creator"
+                                 referencedTableName="users" referencedColumnNames="user_id"/>
+        <addForeignKeyConstraint constraintName="queue_room_changed_by_fk"
+                                 baseTableName="queue_room" baseColumnNames="changed_by"
+                                 referencedTableName="users" referencedColumnNames="user_id"/>
+        <addForeignKeyConstraint constraintName="queue_room_voided_by_fk"
+                                 baseTableName="queue_room" baseColumnNames="retired_by"
+                                 referencedTableName="users" referencedColumnNames="user_id"/>
+        <addForeignKeyConstraint baseTableName="queue_room" baseColumnNames="queue_id"
+                                 constraintName="queue_room_queue_id_fk"
+                                 referencedTableName="queue" referencedColumnNames="queue_id"/>
+    </changeSet>
 
 </databaseChangeLog>

--- a/api/src/main/resources/moduleApplicationContext.xml
+++ b/api/src/main/resources/moduleApplicationContext.xml
@@ -83,6 +83,25 @@
             </list>
         </property>
     </bean>
+    <bean id="queue.QueueRoomService"
+          class="org.springframework.transaction.interceptor.TransactionProxyFactoryBean">
+        <property name="transactionManager" ref="transactionManager"/>
+        <property name="target">
+            <bean class="org.openmrs.module.queue.api.impl.QueueRoomServiceImpl">
+                <property name="dao" ref="queueRoomDao"/>
+            </bean>
+        </property>
+        <property name="preInterceptors" ref="serviceInterceptors"/>
+        <property name="transactionAttributeSource" ref="transactionAttributeSource"/>
+    </bean>
+    <bean parent="serviceContext">
+        <property name="moduleService">
+            <list>
+                <value>org.openmrs.module.queue.api.QueueRoomService</value>
+                <ref bean="queue.QueueRoomService"/>
+            </list>
+        </property>
+    </bean>
     <bean id="queueDao" class="org.openmrs.module.queue.api.dao.impl.QueueDaoImpl">
         <constructor-arg ref="sessionFactory"/>
     </bean>
@@ -90,6 +109,9 @@
         <constructor-arg ref="sessionFactory"/>
     </bean>
     <bean id="visitQueueEntryDao" class="org.openmrs.module.queue.api.dao.impl.VisitQueueEntryDaoImpl">
+        <constructor-arg ref="sessionFactory"/>
+    </bean>
+    <bean id="queueRoomDao" class="org.openmrs.module.queue.api.dao.impl.QueueRoomDaoImpl">
         <constructor-arg ref="sessionFactory"/>
     </bean>
 </beans>

--- a/api/src/main/resources/moduleApplicationContext.xml
+++ b/api/src/main/resources/moduleApplicationContext.xml
@@ -102,6 +102,25 @@
             </list>
         </property>
     </bean>
+    <bean id="queue.RoomProviderMapService"
+          class="org.springframework.transaction.interceptor.TransactionProxyFactoryBean">
+        <property name="transactionManager" ref="transactionManager"/>
+        <property name="target">
+            <bean class="org.openmrs.module.queue.api.impl.RoomProviderMapServiceImpl">
+                <property name="dao" ref="roomProviderMapDao"/>
+            </bean>
+        </property>
+        <property name="preInterceptors" ref="serviceInterceptors"/>
+        <property name="transactionAttributeSource" ref="transactionAttributeSource"/>
+    </bean>
+    <bean parent="serviceContext">
+        <property name="moduleService">
+            <list>
+                <value>org.openmrs.module.queue.api.RoomProviderMapService</value>
+                <ref bean="queue.RoomProviderMapService"/>
+            </list>
+        </property>
+    </bean>
     <bean id="queueDao" class="org.openmrs.module.queue.api.dao.impl.QueueDaoImpl">
         <constructor-arg ref="sessionFactory"/>
     </bean>
@@ -112,6 +131,9 @@
         <constructor-arg ref="sessionFactory"/>
     </bean>
     <bean id="queueRoomDao" class="org.openmrs.module.queue.api.dao.impl.QueueRoomDaoImpl">
+        <constructor-arg ref="sessionFactory"/>
+    </bean>
+    <bean id="roomProviderMapDao" class="org.openmrs.module.queue.api.dao.impl.RoomProviderMapDaoImpl">
         <constructor-arg ref="sessionFactory"/>
     </bean>
 </beans>

--- a/api/src/test/java/org/openmrs/module/queue/api/QueueRoomServiceTest.java
+++ b/api/src/test/java/org/openmrs/module/queue/api/QueueRoomServiceTest.java
@@ -1,0 +1,113 @@
+package org.openmrs.module.queue.api;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.openmrs.Location;
+import org.openmrs.module.queue.api.dao.QueueRoomDao;
+import org.openmrs.module.queue.api.impl.QueueRoomServiceImpl;
+import org.openmrs.module.queue.model.Queue;
+import org.openmrs.module.queue.model.QueueRoom;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class QueueRoomServiceTest {
+    private static final String QUEUE_ROOM_UUID = "4eb8fe43-2813-4kbc-80dc-2e5d30252cc6";
+
+    private static final String QUEUE_ROOM_NAME = "Triage Room 1";
+
+    private static final String QUEUE_UUID = "3eb7fe43-2813-4kbc-80dc-2e5d30252bb5";
+
+    private static final String LOCATION_UUID = "d0938432-1691-11df-97a5-7038c098";
+
+    private QueueRoomServiceImpl queueRoomService;
+
+    @Mock
+    private QueueRoomDao dao;
+
+    @Before
+    public void setupMocks() {
+        MockitoAnnotations.openMocks(this);
+        queueRoomService = new QueueRoomServiceImpl();
+        queueRoomService.setDao(dao);
+    }
+
+    @Test
+    public void shouldGetByUuid() {
+        QueueRoom queueRoom = mock(QueueRoom.class);
+        when(queueRoom.getUuid()).thenReturn(QUEUE_ROOM_UUID);
+        when(dao.get(QUEUE_ROOM_UUID)).thenReturn(Optional.of(queueRoom));
+
+        Optional<QueueRoom> result = queueRoomService.getQueueRoomByUuid(QUEUE_ROOM_UUID);
+        assertThat(result.isPresent(), is(true));
+        result.ifPresent(q -> assertThat(q.getUuid(), is(QUEUE_ROOM_UUID)));
+    }
+
+    @Test
+    public void shouldCreateNewQueue() {
+        QueueRoom queueRoom = mock(QueueRoom.class);
+        when(queueRoom.getUuid()).thenReturn(QUEUE_ROOM_UUID);
+        when(queueRoom.getName()).thenReturn(QUEUE_ROOM_NAME);
+        when(dao.createOrUpdate(queueRoom)).thenReturn(queueRoom);
+
+        QueueRoom result = queueRoomService.createQueueRoom(queueRoom);
+        assertThat(result, notNullValue());
+        assertThat(result.getUuid(), is(QUEUE_ROOM_UUID));
+        assertThat(result.getName(), is(QUEUE_ROOM_NAME));
+    }
+
+    @Test
+    public void shouldVoidQueue() {
+        when(dao.get(QUEUE_ROOM_UUID)).thenReturn(Optional.empty());
+
+        queueRoomService.voidQueueRoom(QUEUE_ROOM_UUID, "API Call");
+
+        assertThat(queueRoomService.getQueueRoomByUuid(QUEUE_ROOM_UUID).isPresent(), is(false));
+    }
+
+    @Test
+    public void shouldPurgeQueue() {
+        QueueRoom queueRoom = mock(QueueRoom.class);
+        when(dao.get(QUEUE_ROOM_UUID)).thenReturn(Optional.empty());
+
+        queueRoomService.purgeQueueRoom(queueRoom);
+        assertThat(queueRoomService.getQueueRoomByUuid(QUEUE_ROOM_UUID).isPresent(), is(false));
+    }
+
+    @Test
+    public void shouldGetAllQueueRoomsByLocation() {
+        QueueRoom queueRoom = mock(QueueRoom.class);
+        Location location = new Location();
+        location.setUuid(LOCATION_UUID);
+        when(dao.getQueueRoomsByServiceAndLocation(null,location)).thenReturn(Collections.singletonList(queueRoom));
+
+        List<QueueRoom> queueRoomsByLocation = queueRoomService.getQueueRoomsByServiceAndLocation(null, location);
+        assertThat(queueRoomsByLocation, notNullValue());
+        assertThat(queueRoomsByLocation, hasSize(1));
+    }
+
+    @Test
+    public void shouldGetAllQueueRoomsByQueue() {
+        QueueRoom queueRoom = mock(QueueRoom.class);
+        Queue queue = new Queue();
+        queue.setUuid(QUEUE_UUID);
+        when(dao.getQueueRoomsByServiceAndLocation(queue,null)).thenReturn(Collections.singletonList(queueRoom));
+
+        List<QueueRoom> queueRoomsByLocation = queueRoomService.getQueueRoomsByServiceAndLocation(queue, null);
+        assertThat(queueRoomsByLocation, notNullValue());
+        assertThat(queueRoomsByLocation, hasSize(1));
+    }
+}

--- a/api/src/test/java/org/openmrs/module/queue/api/RoomProviderMapServiceTest.java
+++ b/api/src/test/java/org/openmrs/module/queue/api/RoomProviderMapServiceTest.java
@@ -1,0 +1,110 @@
+package org.openmrs.module.queue.api;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.openmrs.Provider;
+import org.openmrs.module.queue.api.dao.RoomProviderMapDao;
+import org.openmrs.module.queue.api.impl.RoomProviderMapServiceImpl;
+import org.openmrs.module.queue.model.QueueRoom;
+import org.openmrs.module.queue.model.RoomProviderMap;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RoomProviderMapServiceTest {
+
+    private static final String ROOM_PROVIDER_MAP_UUID = "4eb8fe43-2813-4kbc-80dc-2e5d30252cc6";
+
+    private static final String QUEUE_ROOM_UUID = "4eb8fe43-2813-4kbc-80dc-2e5d30252cc6";
+
+    private static final String PROVIDER_UUID = "a2c3868a-6b90-11e0-93c3-18a905e044dc";
+
+    private RoomProviderMapServiceImpl roomProviderMapService;
+
+    @Mock
+    private RoomProviderMapDao dao;
+
+    @Before
+    public void setupMocks() {
+        MockitoAnnotations.openMocks(this);
+        roomProviderMapService = new RoomProviderMapServiceImpl();
+        roomProviderMapService.setDao(dao);
+    }
+
+    @Test
+    public void shouldGetByUuid() {
+        RoomProviderMap roomProviderMap = mock(RoomProviderMap.class);
+        when(roomProviderMap.getUuid()).thenReturn(ROOM_PROVIDER_MAP_UUID);
+        when(dao.get(ROOM_PROVIDER_MAP_UUID)).thenReturn(Optional.of(roomProviderMap));
+
+        Optional<RoomProviderMap> result = roomProviderMapService.getRoomProviderMapByUuid(ROOM_PROVIDER_MAP_UUID);
+        assertThat(result.isPresent(), is(true));
+        result.ifPresent(q -> assertThat(q.getUuid(), is(ROOM_PROVIDER_MAP_UUID)));
+    }
+
+    @Test
+    public void shouldCreateNewRoomProviderMap() {
+        RoomProviderMap roomProviderMap = mock(RoomProviderMap.class);
+        when(roomProviderMap.getUuid()).thenReturn(ROOM_PROVIDER_MAP_UUID);
+        when(dao.createOrUpdate(roomProviderMap)).thenReturn(roomProviderMap);
+
+        RoomProviderMap result = roomProviderMapService.createRoomProviderMap(roomProviderMap);
+        assertThat(result, notNullValue());
+        assertThat(result.getUuid(), is(ROOM_PROVIDER_MAP_UUID));
+    }
+
+    @Test
+    public void shouldVoidRoomProviderMap() {
+        when(dao.get(ROOM_PROVIDER_MAP_UUID)).thenReturn(Optional.empty());
+
+        roomProviderMapService.voidRoomProviderMap(ROOM_PROVIDER_MAP_UUID, "API Call");
+
+        assertThat(roomProviderMapService.getRoomProviderMapByUuid(ROOM_PROVIDER_MAP_UUID).isPresent(), is(false));
+    }
+
+    @Test
+    public void shouldPurgeRoomProviderMap() {
+        RoomProviderMap roomProviderMap = mock(RoomProviderMap.class);
+        when(dao.get(QUEUE_ROOM_UUID)).thenReturn(Optional.empty());
+
+        roomProviderMapService.purgeRoomProviderMap(roomProviderMap);
+        assertThat(roomProviderMapService.getRoomProviderMapByUuid(ROOM_PROVIDER_MAP_UUID).isPresent(), is(false));
+    }
+
+    @Test
+    public void shouldGetAllRoomProviderMapByProvider() {
+        RoomProviderMap roomProviderMap = mock(RoomProviderMap.class);
+        Provider provider = new Provider();
+        provider.setUuid(PROVIDER_UUID);
+        when(dao.getRoomProvider(provider,null)).thenReturn(Collections.singletonList(roomProviderMap));
+
+        List<RoomProviderMap> result = roomProviderMapService.getRoomProvider(provider, null);
+        assertThat(result, notNullValue());
+        assertThat(result, hasSize(1));
+    }
+
+    @Test
+    public void shouldGetAllRoomProviderMapByQueueRoom() {
+        QueueRoom queueRoom = new QueueRoom();
+        queueRoom.setUuid(QUEUE_ROOM_UUID);
+        RoomProviderMap roomProviderMap = mock(RoomProviderMap.class);
+        when(dao.getRoomProvider(null,queueRoom)).thenReturn(Collections.singletonList(roomProviderMap));
+
+        List<RoomProviderMap> result = roomProviderMapService.getRoomProvider(null, queueRoom);
+        assertThat(result, notNullValue());
+        assertThat(result, hasSize(1));
+    }
+}

--- a/api/src/test/java/org/openmrs/module/queue/api/dao/QueueRoomDaoTest.java
+++ b/api/src/test/java/org/openmrs/module/queue/api/dao/QueueRoomDaoTest.java
@@ -133,7 +133,7 @@ public class QueueRoomDaoTest extends BaseModuleContextSensitiveTest {
     }
 
     @Test
-    public void shouldFindQueueRoomByService() {
+    public void shouldFindQueueRoomByQueue() {
         Queue queue = queueDao.get(QUEUE_UUID).get();
 
         List<QueueRoom> roomsByQueue = dao.getQueueRoomsByServiceAndLocation(queue, null);

--- a/api/src/test/java/org/openmrs/module/queue/api/dao/QueueRoomDaoTest.java
+++ b/api/src/test/java/org/openmrs/module/queue/api/dao/QueueRoomDaoTest.java
@@ -1,0 +1,178 @@
+package org.openmrs.module.queue.api.dao;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.openmrs.Location;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.queue.SpringTestConfiguration;
+import org.openmrs.module.queue.model.Queue;
+import org.openmrs.module.queue.model.QueueRoom;
+import org.openmrs.test.BaseModuleContextSensitiveTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.test.context.ContextConfiguration;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+@ContextConfiguration(classes = SpringTestConfiguration.class, inheritLocations = false)
+public class QueueRoomDaoTest extends BaseModuleContextSensitiveTest {
+
+    private static final List<String> QUEUE_ROOM_INITIAL_DATASET_XML = Arrays.asList(
+            "org/openmrs/module/queue/api/dao/QueueDaoTest_locationInitialDataset.xml",
+            "org/openmrs/module/queue/api/dao/QueueDaoTest_conceptsInitialDataset.xml",
+            "org/openmrs/module/queue/api/dao/QueueDaoTest_initialDataset.xml",
+            "org/openmrs/module/queue/api/dao/QueueRoomDaoTest_initialDataset.xml"
+            );
+
+    private static final String QUEUE_ROOM_UUID = "4eb8fe43-2813-4kbc-80dc-2e5d30252cc6";
+
+    private static final String RETIRED_QUEUE_ROOM_UUID = "4eb8fe43-2813-4kbc-80dc-2e5d30252cc8";
+
+    private static final String NEW_QUEUE_ROOM_UUID = "4eb8fe43-2813-4kbc-80dc-2e5d30252c10";
+
+    private static final String NEW_QUEUE_ROOM_NAME = "Triage Room 1";
+
+    private static final String QUEUE_UUID = "3eb7fe43-2813-4kbc-80dc-2e5d30252bb5";
+
+    private static final String LOCATION_UUID = "d0938432-1691-11df-97a5-7038c098";
+
+    @Autowired
+    @Qualifier("queueRoomDao")
+    private QueueRoomDao dao;
+
+    @Autowired
+    @Qualifier("queueDao")
+    private QueueDao<Queue> queueDao;
+
+
+    @Before
+    public void setup() {
+        QUEUE_ROOM_INITIAL_DATASET_XML.forEach(this::executeDataSet);
+    }
+
+    @Test
+    public void shouldGetQueueRoomById() {
+        Optional<QueueRoom> queueRoom = dao.get(1);
+
+        assertThat(queueRoom, notNullValue());
+        assertThat(queueRoom.isPresent(), is(true));
+        queueRoom.ifPresent(queueRoom1 -> assertThat(queueRoom1.getId(), is(1)));
+    }
+
+    @Test
+    public void shouldGetQueueRoomByUuid() {
+        Optional<QueueRoom> queueRoom = dao.get(QUEUE_ROOM_UUID);
+
+        assertThat(queueRoom, notNullValue());
+        assertThat(queueRoom.isPresent(), is(true));
+        queueRoom.ifPresent(queueRoom1 -> assertThat(queueRoom1.getUuid(), is(QUEUE_ROOM_UUID)));
+    }
+
+    @Test
+    public void shouldReturnNullForRetiredQueueRoom() {
+        Optional<QueueRoom> queueRoom = dao.get(RETIRED_QUEUE_ROOM_UUID);
+        assertThat(queueRoom.isPresent(), is(false));
+    }
+
+    @Test
+    public void shouldCreateNewQueueRoom() {
+        QueueRoom queueRoom = new QueueRoom();
+        queueRoom.setUuid(NEW_QUEUE_ROOM_UUID);
+        queueRoom.setName(NEW_QUEUE_ROOM_NAME);
+        queueRoom.setQueue(queueDao.get(QUEUE_UUID).get());
+
+        QueueRoom result = dao.createOrUpdate(queueRoom);
+        assertThat(result, notNullValue());
+        assertThat(result.getUuid(), is(NEW_QUEUE_ROOM_UUID));
+
+        //Get the saved queue room version
+        Optional<QueueRoom> newlyCreatedQueueRoom = dao.get(NEW_QUEUE_ROOM_UUID);
+        assertThat(newlyCreatedQueueRoom.isPresent(), is(true));
+        newlyCreatedQueueRoom.ifPresent(createdQueueRoom -> {
+            assertThat(createdQueueRoom.getUuid(), is(NEW_QUEUE_ROOM_UUID));
+            assertThat(createdQueueRoom.getName(), is(NEW_QUEUE_ROOM_NAME));
+        });
+    }
+
+    @Test
+    public void shouldUpdateQueueRoom() {
+        //Get saved queue room
+        Optional<QueueRoom> persistedRoom = dao.get(QUEUE_ROOM_UUID);
+        assertThat(persistedRoom.isPresent(), is(true));
+        persistedRoom.ifPresent(queueDb -> {
+            assertThat(queueDb.getUuid(), is(QUEUE_ROOM_UUID));
+            assertThat(queueDb.getName(), is(NEW_QUEUE_ROOM_NAME));
+        });
+        //Update Queue room name
+        QueueRoom toUpdate = persistedRoom.get();
+        toUpdate.setName("Triage New Room");
+        dao.createOrUpdate(toUpdate);
+        //Verify the update operation
+        Optional<QueueRoom> updatedQueue = dao.get(toUpdate.getUuid());
+        assertThat(updatedQueue.isPresent(), is(true));
+        updatedQueue.ifPresent(revisedQueue -> assertThat(revisedQueue.getName(), is("Triage New Room")));
+    }
+
+    @Test
+    public void shouldFindQueueRoomByLocation() {
+        Location location = Context.getLocationService().getLocationByUuid(LOCATION_UUID);
+
+        List<QueueRoom> roomsByLocation = dao.getQueueRoomsByServiceAndLocation(null, location);
+
+        assertThat(roomsByLocation, notNullValue());
+        assertThat(roomsByLocation, hasSize(2));
+        roomsByLocation.forEach(room -> assertThat(room.getQueue().getLocation().getUuid(), is(LOCATION_UUID)));
+    }
+
+    @Test
+    public void shouldFindQueueRoomByService() {
+        Queue queue = queueDao.get(QUEUE_UUID).get();
+
+        List<QueueRoom> roomsByQueue = dao.getQueueRoomsByServiceAndLocation(queue, null);
+
+        assertThat(roomsByQueue, notNullValue());
+        assertThat(roomsByQueue, hasSize(2));
+        roomsByQueue.forEach(room -> assertThat(room.getQueue().getUuid(), is(QUEUE_UUID)));
+    }
+
+    @Test
+    public void shouldDeleteQueueRoomByUuid() {
+        dao.delete(QUEUE_ROOM_UUID);
+
+        Optional<QueueRoom> result = dao.get(QUEUE_ROOM_UUID);
+        //verify delete operation
+        assertThat(result.isPresent(), is(false));
+    }
+
+    @Test
+    public void shouldDeleteQueueRoomByEntity() {
+        dao.get(QUEUE_ROOM_UUID).ifPresent((queue) -> dao.delete(queue));
+
+        Optional<QueueRoom> result = dao.get(QUEUE_ROOM_UUID);
+        //verify delete operation
+        assertThat(result.isPresent(), is(false));
+    }
+
+    @Test
+    public void shouldFindAllQueueRooms() {
+        Collection<QueueRoom> queueRooms = dao.findAll();
+        assertThat(queueRooms.isEmpty(), is(false));
+        assertThat(queueRooms, hasSize(2));
+    }
+
+
+    @Test
+    public void shouldFindAllQueueRoomsIncludingRetired() {
+        Collection<QueueRoom> queueRooms = dao.findAll(true);
+        assertThat(queueRooms.isEmpty(), is(false));
+        assertThat(queueRooms, hasSize(3));
+    }
+}

--- a/api/src/test/java/org/openmrs/module/queue/api/dao/RoomProviderMapDaoTest.java
+++ b/api/src/test/java/org/openmrs/module/queue/api/dao/RoomProviderMapDaoTest.java
@@ -1,0 +1,182 @@
+package org.openmrs.module.queue.api.dao;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.openmrs.Provider;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.queue.SpringTestConfiguration;
+import org.openmrs.module.queue.model.QueueRoom;
+import org.openmrs.module.queue.model.RoomProviderMap;
+import org.openmrs.test.BaseModuleContextSensitiveTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.test.context.ContextConfiguration;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+@ContextConfiguration(classes = SpringTestConfiguration.class, inheritLocations = false)
+public class RoomProviderMapDaoTest extends BaseModuleContextSensitiveTest {
+
+    private static final List<String> QUEUE_ROOM_INITIAL_DATASET_XML = Arrays.asList(
+            "org/openmrs/module/queue/api/dao/QueueDaoTest_locationInitialDataset.xml",
+            "org/openmrs/module/queue/api/dao/QueueDaoTest_conceptsInitialDataset.xml",
+            "org/openmrs/module/queue/api/dao/QueueDaoTest_initialDataset.xml",
+            "org/openmrs/module/queue/api/dao/QueueRoomDaoTest_initialDataset.xml",
+            "org/openmrs/module/queue/api/dao/RoomProviderMapDaoTest_initialDataset.xml"
+    );
+
+    private static final String ROOM_PROVIDER_MAP_UUID = "4eb8fe43-2813-4kbc-80dc-2e5d30252cc6";
+
+    private static final String RETIRED_ROOM_PROVIDER_MAP__UUID = "4eb8fe43-2813-4kbc-80dc-2e5d30252cc8";
+
+    private static final String NEW_ROOM_PROVIDER_MAP_UUID = "4eb8fe43-2813-4kbc-80dc-2e5d30252c10";
+
+    private static final String QUEUE_ROOM_UUID = "4eb8fe43-2813-4kbc-80dc-2e5d30252cc6";
+
+    private static final String PROVIDER_UUID = "a2c3868a-6b90-11e0-93c3-18a905e044dc";
+
+    private static final String UPDATE_PROVIDER_UUID = "a3a5913e-6b94-11e0-93c3-18a905e044dc";
+
+    @Autowired
+    @Qualifier("roomProviderMapDao")
+    private RoomProviderMapDao dao;
+
+    @Autowired
+    @Qualifier("queueRoomDao")
+    private QueueRoomDao queueRoomDao;
+
+    @Before
+    public void setup() {
+        QUEUE_ROOM_INITIAL_DATASET_XML.forEach(this::executeDataSet);
+    }
+
+    @Test
+    public void shouldGetRoomProviderMapById() {
+        Optional<RoomProviderMap> providerRoom = dao.get(1);
+
+        assertThat(providerRoom, notNullValue());
+        assertThat(providerRoom.isPresent(), is(true));
+        providerRoom.ifPresent(providerRoom1 -> assertThat(providerRoom1.getId(), is(1)));
+    }
+
+    @Test
+    public void shouldGetRoomProviderMapByUuid() {
+        Optional<RoomProviderMap> providerRoom = dao.get(QUEUE_ROOM_UUID);
+
+        assertThat(providerRoom, notNullValue());
+        assertThat(providerRoom.isPresent(), is(true));
+        providerRoom.ifPresent(providerRoom1 -> assertThat(providerRoom1.getUuid(), is(QUEUE_ROOM_UUID)));
+    }
+
+    @Test
+    public void shouldReturnNullForRetiredRoomProviderMap() {
+        Optional<RoomProviderMap> queueRoom = dao.get(RETIRED_ROOM_PROVIDER_MAP__UUID);
+        assertThat(queueRoom.isPresent(), is(false));
+    }
+
+    @Test
+    public void shouldCreateNewRoomProviderMap() {
+        QueueRoom queueRoom = queueRoomDao.get(QUEUE_ROOM_UUID).get();
+        Provider provider = Context.getProviderService().getProviderByUuid(PROVIDER_UUID);
+
+        RoomProviderMap providerRoom = new RoomProviderMap();
+        providerRoom.setUuid(NEW_ROOM_PROVIDER_MAP_UUID);
+        providerRoom.setQueueRoom(queueRoom);
+        providerRoom.setProvider(provider);
+
+        RoomProviderMap result = dao.createOrUpdate(providerRoom);
+        assertThat(result, notNullValue());
+        assertThat(result.getUuid(), is(NEW_ROOM_PROVIDER_MAP_UUID));
+
+        //Get the saved provider's room version
+        Optional<RoomProviderMap> newlyCreated= dao.get(NEW_ROOM_PROVIDER_MAP_UUID);
+        assertThat(newlyCreated.isPresent(), is(true));
+        newlyCreated.ifPresent(createdQueueRoom -> {
+            assertThat(createdQueueRoom.getUuid(), is(NEW_ROOM_PROVIDER_MAP_UUID));
+            assertThat(createdQueueRoom.getProvider().getUuid(), is(PROVIDER_UUID));
+        });
+    }
+
+    @Test
+    public void shouldUpdateRoomProviderMap() {
+        //Get saved queue room
+        Optional<RoomProviderMap> persistedRoom = dao.get(ROOM_PROVIDER_MAP_UUID);
+        assertThat(persistedRoom.isPresent(), is(true));
+        persistedRoom.ifPresent(queueDb -> {
+            assertThat(queueDb.getUuid(), is(ROOM_PROVIDER_MAP_UUID));
+            assertThat(queueDb.getProvider().getUuid(), is(PROVIDER_UUID));
+        });
+        //Update Queue room name
+        RoomProviderMap toUpdate = persistedRoom.get();
+        Provider provider = Context.getProviderService().getProviderByUuid(UPDATE_PROVIDER_UUID);
+        toUpdate.setProvider(provider);
+        dao.createOrUpdate(toUpdate);
+        //Verify the update operation
+        Optional<RoomProviderMap> updatedRoom = dao.get(toUpdate.getUuid());
+        assertThat(updatedRoom.isPresent(), is(true));
+        updatedRoom.ifPresent(pr -> assertThat(pr.getProvider().getUuid(), is(UPDATE_PROVIDER_UUID)));
+    }
+
+    @Test
+    public void shouldDeleteRoomProviderMapByUuid() {
+        dao.delete(ROOM_PROVIDER_MAP_UUID);
+
+        Optional<RoomProviderMap> result = dao.get(ROOM_PROVIDER_MAP_UUID);
+        //verify delete operation
+        assertThat(result.isPresent(), is(false));
+    }
+
+    @Test
+    public void shouldDeleteRoomProviderMapByEntity() {
+        dao.get(ROOM_PROVIDER_MAP_UUID).ifPresent((queue) -> dao.delete(queue));
+
+        Optional<RoomProviderMap> result = dao.get(ROOM_PROVIDER_MAP_UUID);
+        //verify delete operation
+        assertThat(result.isPresent(), is(false));
+    }
+
+    @Test
+    public void shouldFindAllRoomProviderMaps() {
+        Collection<RoomProviderMap> room = dao.findAll();
+        assertThat(room.isEmpty(), is(false));
+        assertThat(room, hasSize(2));
+    }
+
+
+    @Test
+    public void shouldFindAllQueueRoomProviderMapsIncludingRetired() {
+        Collection<RoomProviderMap> rooms = dao.findAll(true);
+        assertThat(rooms.isEmpty(), is(false));
+        assertThat(rooms, hasSize(3));
+    }
+
+    @Test
+    public void shouldFindByQueueRoom() {
+        Optional<QueueRoom> queueRoom = queueRoomDao.get(QUEUE_ROOM_UUID);
+
+        List<RoomProviderMap> result = dao.getRoomProvider(null, queueRoom.get());
+
+        assertThat(result, notNullValue());
+        assertThat(result, hasSize(1));
+        result.forEach(room -> assertThat(room.getQueueRoom().getUuid(), is(QUEUE_ROOM_UUID)));
+    }
+
+    @Test
+    public void shouldFindByProvider() {
+        Provider provider = Context.getProviderService().getProviderByUuid(PROVIDER_UUID);
+
+        List<RoomProviderMap> result = dao.getRoomProvider(provider, null);
+
+        assertThat(result, notNullValue());
+        assertThat(result, hasSize(1));
+        result.forEach(room -> assertThat(room.getProvider().getUuid(), is(PROVIDER_UUID)));
+    }
+}

--- a/api/src/test/resources/org/openmrs/module/queue/api/dao/QueueDaoTest_conceptsInitialDataset.xml
+++ b/api/src/test/resources/org/openmrs/module/queue/api/dao/QueueDaoTest_conceptsInitialDataset.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+    This Source Code Form is subject to the terms of the Mozilla Public License,
+    v. 2.0. If a copy of the MPL was not distributed with this file, You can
+    obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+    the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
+    Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+    graphic logo is a trademark of OpenMRS Inc.
+-->
+<dataset>
+    <!--A concept set of queue service -->
+    <concept concept_id="2000" retired="false" is_set="true" creator="1" date_created="2022-02-02 14:31:00.0" uuid="907eba27-2b38-43e8-91a9-4dfe3956a35t"/>
+    <concept concept_id="2001" retired="false" is_set="false" creator="1" date_created="2022-02-02 14:40:00.0" uuid="67b910bd-298c-4ecf-a632-661ae2f446op"/>
+    <concept concept_id="2002" retired="false" is_set="false" creator="1" date_created="2022-03-08 15:40:00.0" uuid="68b910bd-298c-4ecf-a632-661ae2f446op"/>
+    <concept_name concept_name_id="893" concept_id="2000" name="Queue Service" locale="en" creator="1" date_created="2022-02-02 14:40:00.0" voided="0" uuid="9cp62348-5bf2-4050-b824-0aa009436ed6" concept_name_type="FULLY_SPECIFIED" locale_preferred="0"/>
+    <concept_name concept_name_id="210" concept_id="2001" name="Triage" locale="en" creator="1" date_created="2022-02-02 14:40:00.0" voided="0" uuid="9i667348-5bf2-4050-b824-0aa009436kl0" concept_name_type="FULLY_SPECIFIED" locale_preferred="0"/>
+    <concept_name concept_name_id="211" concept_id="2002" name="Consultation" locale="en" creator="1" date_created="2022-02-02 14:40:00.0" voided="0" uuid="5t747348-5bf2-4050-b824-0aa009436kl0" concept_name_type="FULLY_SPECIFIED" locale_preferred="0"/>
+    <concept_set concept_set_id="389000" concept_set="2000" concept_id="2001" sort_weight="0" date_created="2022-02-02 14:40:00.0" creator="1" uuid="470b910bd-298c-4ecf-a632-661ae2f886bf"/>
+    <concept_set concept_set_id="389001" concept_set="2000" concept_id="2002" sort_weight="0" date_created="2022-03-08 15:50:00.0" creator="1" uuid="380b910bd-298c-4ecf-a632-661ae2f886bf"/>
+</dataset>

--- a/api/src/test/resources/org/openmrs/module/queue/api/dao/QueueRoomDaoTest_initialDataset.xml
+++ b/api/src/test/resources/org/openmrs/module/queue/api/dao/QueueRoomDaoTest_initialDataset.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+    This Source Code Form is subject to the terms of the Mozilla Public License,
+    v. 2.0. If a copy of the MPL was not distributed with this file, You can
+    obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+    the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
+    Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+    graphic logo is a trademark of OpenMRS Inc.
+-->
+<dataset>
+    <queue_room queue_room_id="1"  queue_id="1"  name="Triage Room 1" description="This is description" creator="1" date_created="2022-02-02 16:38:56.0"
+                retired="false" uuid="4eb8fe43-2813-4kbc-80dc-2e5d30252cc6"/>
+
+    <queue_room queue_room_id="2"  queue_id="1"  name="Triage Room 2" description="This is description" creator="1" date_created="2022-02-02 16:38:56.0"
+                retired="false" uuid="4eb8fe43-2813-4kbc-80dc-2e5d30252cc7"/>
+
+    <!--Retired Room entry -->
+    <queue_room queue_room_id="3"  queue_id="1"  name="Triage Room 3" description="This is description" creator="1" date_created="2022-02-02 16:38:56.0"
+                retired="true" uuid="4eb8fe43-2813-4kbc-80dc-2e5d30252cc8"/>
+</dataset>

--- a/api/src/test/resources/org/openmrs/module/queue/api/dao/RoomProviderMapDaoTest_initialDataset.xml
+++ b/api/src/test/resources/org/openmrs/module/queue/api/dao/RoomProviderMapDaoTest_initialDataset.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+    This Source Code Form is subject to the terms of the Mozilla Public License,
+    v. 2.0. If a copy of the MPL was not distributed with this file, You can
+    obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+    the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
+    Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+    graphic logo is a trademark of OpenMRS Inc.
+-->
+<dataset>
+    <provider provider_id="1" 	name="RobertClive" identifier="8A760" creator="1"  date_created="2005-01-01 00:00:00.0" retired="0" uuid="a2c3868a-6b90-11e0-93c3-18a905e044dc" />
+    <provider provider_id="2" 	name="Roger" person_id="2" identifier="8A761" creator="1"  date_created="2005-01-01 00:00:00.0" retired="0" uuid="a3a5913e-6b94-11e0-93c3-18a905e044dc" />
+
+    <room_provider_map  room_provider_map_id="1" queue_room_id="1" provider_id="1" creator="1" date_created="2022-02-02 16:38:56.0" voided="false" uuid="4eb8fe43-2813-4kbc-80dc-2e5d30252cc6"/>
+
+    <room_provider_map room_provider_map_id="2" queue_room_id="2" provider_id="2" creator="1" date_created="2022-02-02 16:38:56.0" voided="false" uuid="4eb8fe43-2813-4kbc-80dc-2e5d30252cc7"/>
+
+    <!--Retired Room entry -->
+    <room_provider_map room_provider_map_id="3" queue_room_id="3" provider_id="2" creator="1" date_created="2022-02-02 16:38:56.0" voided="true" uuid="4eb8fe43-2813-4kbc-80dc-2e5d30252cc8"/>
+</dataset>

--- a/omod/src/main/java/org/openmrs/module/queue/web/resources/QueueRoomResource.java
+++ b/omod/src/main/java/org/openmrs/module/queue/web/resources/QueueRoomResource.java
@@ -1,0 +1,123 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.queue.web.resources;
+
+import java.util.Optional;
+
+import org.openmrs.api.context.Context;
+import org.openmrs.module.queue.api.QueueRoomService;
+import org.openmrs.module.queue.model.QueueRoom;
+import org.openmrs.module.webservices.rest.web.RequestContext;
+import org.openmrs.module.webservices.rest.web.RestConstants;
+import org.openmrs.module.webservices.rest.web.annotation.PropertyGetter;
+import org.openmrs.module.webservices.rest.web.annotation.Resource;
+import org.openmrs.module.webservices.rest.web.representation.CustomRepresentation;
+import org.openmrs.module.webservices.rest.web.representation.DefaultRepresentation;
+import org.openmrs.module.webservices.rest.web.representation.FullRepresentation;
+import org.openmrs.module.webservices.rest.web.representation.RefRepresentation;
+import org.openmrs.module.webservices.rest.web.representation.Representation;
+import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingCrudResource;
+import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceDescription;
+import org.openmrs.module.webservices.rest.web.response.ObjectNotFoundException;
+import org.openmrs.module.webservices.rest.web.response.ResourceDoesNotSupportOperationException;
+import org.openmrs.module.webservices.rest.web.response.ResponseException;
+
+@Resource(name = RestConstants.VERSION_1 + "/queueroom", supportedClass = QueueRoom.class, supportedOpenmrsVersions = {
+        "2.0 - 2.*" })
+public class QueueRoomResource extends DelegatingCrudResource<QueueRoom> {
+	
+	private final QueueRoomService queueRoomService;
+	
+	public QueueRoomResource() {
+		this.queueRoomService = Context.getService(QueueRoomService.class);
+	}
+	
+	@Override
+	public QueueRoom getByUniqueId(String uuid) {
+		Optional<QueueRoom> optionalQueueRoom = queueRoomService.getQueueRoomByUuid(uuid);
+		if (!optionalQueueRoom.isPresent()) {
+			throw new ObjectNotFoundException("Could not find queueRoom with UUID " + uuid);
+		}
+		return optionalQueueRoom.get();
+	}
+	
+	@Override
+	protected void delete(QueueRoom queueRoom, String s, RequestContext requestContext) throws ResponseException {
+	}
+	
+	@Override
+	public QueueRoom newDelegate() {
+		return new QueueRoom();
+	}
+	
+	@Override
+	public QueueRoom save(QueueRoom queueRoom) {
+		return queueRoomService.createQueueRoom(queueRoom);
+	}
+	
+	@Override
+	public void purge(QueueRoom queueRoom, RequestContext requestContext) throws ResponseException {
+		
+	}
+	
+	@Override
+	public DelegatingResourceDescription getRepresentationDescription(Representation representation) {
+		DelegatingResourceDescription resourceDescription = new DelegatingResourceDescription();
+		if (representation instanceof RefRepresentation) {
+			this.addSharedResourceDescriptionProperties(resourceDescription);
+			resourceDescription.addLink("full", ".?v=" + RestConstants.REPRESENTATION_FULL);
+		} else if (representation instanceof DefaultRepresentation) {
+			this.addSharedResourceDescriptionProperties(resourceDescription);
+			resourceDescription.addProperty("queue", Representation.REF);
+			resourceDescription.addLink("full", ".?v=" + RestConstants.REPRESENTATION_FULL);
+		} else if (representation instanceof FullRepresentation) {
+			this.addSharedResourceDescriptionProperties(resourceDescription);
+			resourceDescription.addProperty("queue", Representation.FULL);
+			resourceDescription.addProperty("auditInfo");
+		} else if (representation instanceof CustomRepresentation) {
+			//For custom representation, must be null
+			// - let the user decide which properties should be included in the response
+			resourceDescription = null;
+		}
+		return resourceDescription;
+	}
+	
+	private void addSharedResourceDescriptionProperties(DelegatingResourceDescription resourceDescription) {
+		resourceDescription.addSelfLink();
+		resourceDescription.addProperty("uuid");
+		resourceDescription.addProperty("display");
+		resourceDescription.addProperty("name");
+		resourceDescription.addProperty("description");
+	}
+	
+	@Override
+	public DelegatingResourceDescription getCreatableProperties() throws ResourceDoesNotSupportOperationException {
+		DelegatingResourceDescription resourceDescription = new DelegatingResourceDescription();
+		resourceDescription.addProperty("name");
+		resourceDescription.addProperty("description");
+		resourceDescription.addProperty("queue");
+		return resourceDescription;
+	}
+	
+	@Override
+	public DelegatingResourceDescription getUpdatableProperties() throws ResourceDoesNotSupportOperationException {
+		return this.getCreatableProperties();
+	}
+	
+	@PropertyGetter("display")
+	public String getDisplay(QueueRoom queueRoom) {
+		return queueRoom.getName();
+	}
+	
+	@Override
+	public String getResourceVersion() {
+		return "2.3";
+	}
+}

--- a/omod/src/main/java/org/openmrs/module/queue/web/resources/QueueRoomResource.java
+++ b/omod/src/main/java/org/openmrs/module/queue/web/resources/QueueRoomResource.java
@@ -54,7 +54,11 @@ public class QueueRoomResource extends DelegatingCrudResource<QueueRoom> {
 	}
 	
 	@Override
-	protected void delete(QueueRoom queueRoom, String s, RequestContext requestContext) throws ResponseException {
+	protected void delete(QueueRoom queueRoom, String retireReason, RequestContext requestContext) throws ResponseException {
+		if (!this.queueRoomService.getQueueRoomByUuid(queueRoom.getUuid()).isPresent()) {
+			throw new ObjectNotFoundException("Could not find queue room with uuid " + queueRoom.getUuid());
+		}
+		this.queueRoomService.voidQueueRoom(queueRoom.getUuid(), retireReason);
 	}
 	
 	@Override
@@ -69,7 +73,7 @@ public class QueueRoomResource extends DelegatingCrudResource<QueueRoom> {
 	
 	@Override
 	public void purge(QueueRoom queueRoom, RequestContext requestContext) throws ResponseException {
-		
+		this.queueRoomService.purgeQueueRoom(queueRoom);
 	}
 	
 	@Override

--- a/omod/src/main/java/org/openmrs/module/queue/web/resources/QueueRoomResource.java
+++ b/omod/src/main/java/org/openmrs/module/queue/web/resources/QueueRoomResource.java
@@ -11,8 +11,11 @@ package org.openmrs.module.queue.web.resources;
 
 import java.util.Optional;
 
+import org.openmrs.Location;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.queue.api.QueueRoomService;
+import org.openmrs.module.queue.api.QueueService;
+import org.openmrs.module.queue.model.Queue;
 import org.openmrs.module.queue.model.QueueRoom;
 import org.openmrs.module.webservices.rest.web.RequestContext;
 import org.openmrs.module.webservices.rest.web.RestConstants;
@@ -23,8 +26,10 @@ import org.openmrs.module.webservices.rest.web.representation.DefaultRepresentat
 import org.openmrs.module.webservices.rest.web.representation.FullRepresentation;
 import org.openmrs.module.webservices.rest.web.representation.RefRepresentation;
 import org.openmrs.module.webservices.rest.web.representation.Representation;
+import org.openmrs.module.webservices.rest.web.resource.api.PageableResult;
 import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingCrudResource;
 import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceDescription;
+import org.openmrs.module.webservices.rest.web.resource.impl.NeedsPaging;
 import org.openmrs.module.webservices.rest.web.response.ObjectNotFoundException;
 import org.openmrs.module.webservices.rest.web.response.ResourceDoesNotSupportOperationException;
 import org.openmrs.module.webservices.rest.web.response.ResponseException;
@@ -65,6 +70,17 @@ public class QueueRoomResource extends DelegatingCrudResource<QueueRoom> {
 	@Override
 	public void purge(QueueRoom queueRoom, RequestContext requestContext) throws ResponseException {
 		
+	}
+	
+	@Override
+	protected PageableResult doSearch(RequestContext context) {
+		Queue queue = context.getParameter("queue") != null
+		        ? Context.getService(QueueService.class).getQueueByUuid(context.getParameter("queue")).get()
+		        : null;
+		Location location = context.getParameter("location") != null
+		        ? Context.getLocationService().getLocationByUuid(context.getParameter("location"))
+		        : null;
+		return new NeedsPaging<>(queueRoomService.getQueueRoomsByServiceAndLocation(queue, location), context);
 	}
 	
 	@Override

--- a/omod/src/main/java/org/openmrs/module/queue/web/resources/RoomProviderMapResource.java
+++ b/omod/src/main/java/org/openmrs/module/queue/web/resources/RoomProviderMapResource.java
@@ -1,0 +1,131 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.queue.web.resources;
+
+import java.util.Optional;
+
+import org.openmrs.Provider;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.queue.api.QueueRoomService;
+import org.openmrs.module.queue.api.RoomProviderMapService;
+import org.openmrs.module.queue.model.QueueRoom;
+import org.openmrs.module.queue.model.RoomProviderMap;
+import org.openmrs.module.webservices.rest.web.RequestContext;
+import org.openmrs.module.webservices.rest.web.RestConstants;
+import org.openmrs.module.webservices.rest.web.annotation.Resource;
+import org.openmrs.module.webservices.rest.web.representation.CustomRepresentation;
+import org.openmrs.module.webservices.rest.web.representation.DefaultRepresentation;
+import org.openmrs.module.webservices.rest.web.representation.FullRepresentation;
+import org.openmrs.module.webservices.rest.web.representation.RefRepresentation;
+import org.openmrs.module.webservices.rest.web.representation.Representation;
+import org.openmrs.module.webservices.rest.web.resource.api.PageableResult;
+import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingCrudResource;
+import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceDescription;
+import org.openmrs.module.webservices.rest.web.resource.impl.NeedsPaging;
+import org.openmrs.module.webservices.rest.web.response.ObjectNotFoundException;
+import org.openmrs.module.webservices.rest.web.response.ResourceDoesNotSupportOperationException;
+import org.openmrs.module.webservices.rest.web.response.ResponseException;
+
+@Resource(name = RestConstants.VERSION_1
+        + "/roomprovidermap", supportedClass = RoomProviderMap.class, supportedOpenmrsVersions = { "2.0 - 2.*" })
+public class RoomProviderMapResource extends DelegatingCrudResource<RoomProviderMap> {
+	
+	private final RoomProviderMapService roomProviderMapService;
+	
+	public RoomProviderMapResource() {
+		this.roomProviderMapService = Context.getService(RoomProviderMapService.class);
+	}
+	
+	@Override
+	public RoomProviderMap getByUniqueId(String uuid) {
+		Optional<RoomProviderMap> optionalQueueRoom = roomProviderMapService.getRoomProviderMapByUuid(uuid);
+		if (!optionalQueueRoom.isPresent()) {
+			throw new ObjectNotFoundException("Could not find roomProviderMap with UUID " + uuid);
+		}
+		return optionalQueueRoom.get();
+	}
+	
+	@Override
+	protected void delete(RoomProviderMap roomProviderMap, String s, RequestContext requestContext)
+	        throws ResponseException {
+		
+	}
+	
+	@Override
+	public RoomProviderMap newDelegate() {
+		return new RoomProviderMap();
+	}
+	
+	@Override
+	public RoomProviderMap save(RoomProviderMap roomProviderMap) {
+		return roomProviderMapService.createRoomProviderMap(roomProviderMap);
+	}
+	
+	@Override
+	public void purge(RoomProviderMap roomProviderMap, RequestContext requestContext) throws ResponseException {
+		
+	}
+	
+	@Override
+	protected PageableResult doSearch(RequestContext context) {
+		Provider provider = context.getParameter("provider") != null
+		        ? Context.getProviderService().getProviderByUuid(context.getParameter("provider"))
+		        : null;
+		QueueRoom queueRoom = context.getParameter("queueRoom") != null
+		        ? Context.getService(QueueRoomService.class).getQueueRoomByUuid(context.getParameter("queueRoom")).get()
+		        : null;
+		return new NeedsPaging<>(roomProviderMapService.getRoomProvider(provider, queueRoom), context);
+	}
+	
+	@Override
+	public DelegatingResourceDescription getRepresentationDescription(Representation representation) {
+		DelegatingResourceDescription resourceDescription = new DelegatingResourceDescription();
+		if (representation instanceof RefRepresentation) {
+			this.addSharedResourceDescriptionProperties(resourceDescription);
+			resourceDescription.addProperty("queueRoom", Representation.REF);
+			resourceDescription.addProperty("provider", Representation.REF);
+			resourceDescription.addLink("full", ".?v=" + RestConstants.REPRESENTATION_FULL);
+		} else if (representation instanceof DefaultRepresentation) {
+			this.addSharedResourceDescriptionProperties(resourceDescription);
+			resourceDescription.addProperty("queueRoom", Representation.REF);
+			resourceDescription.addProperty("provider", Representation.REF);
+			resourceDescription.addLink("full", ".?v=" + RestConstants.REPRESENTATION_FULL);
+		} else if (representation instanceof FullRepresentation) {
+			this.addSharedResourceDescriptionProperties(resourceDescription);
+			resourceDescription.addProperty("queueRoom", Representation.FULL);
+			resourceDescription.addProperty("provider", Representation.FULL);
+			resourceDescription.addProperty("auditInfo");
+		} else if (representation instanceof CustomRepresentation) {
+			//For custom representation, must be null
+			// - let the user decide which properties should be included in the response
+			resourceDescription = null;
+		}
+		return resourceDescription;
+	}
+	
+	private void addSharedResourceDescriptionProperties(DelegatingResourceDescription resourceDescription) {
+		resourceDescription.addSelfLink();
+		resourceDescription.addProperty("uuid");
+	}
+	
+	@Override
+	public DelegatingResourceDescription getCreatableProperties() throws ResourceDoesNotSupportOperationException {
+		DelegatingResourceDescription resourceDescription = new DelegatingResourceDescription();
+		resourceDescription.addProperty("queueRoom");
+		resourceDescription.addProperty("provider");
+		return resourceDescription;
+	}
+	
+	@Override
+	public DelegatingResourceDescription getUpdatableProperties() throws ResourceDoesNotSupportOperationException {
+		return this.getCreatableProperties();
+	}
+	
+}

--- a/omod/src/main/java/org/openmrs/module/queue/web/resources/RoomProviderMapResource.java
+++ b/omod/src/main/java/org/openmrs/module/queue/web/resources/RoomProviderMapResource.java
@@ -53,9 +53,12 @@ public class RoomProviderMapResource extends DelegatingCrudResource<RoomProvider
 	}
 	
 	@Override
-	protected void delete(RoomProviderMap roomProviderMap, String s, RequestContext requestContext)
+	protected void delete(RoomProviderMap roomProviderMap, String voidReason, RequestContext requestContext)
 	        throws ResponseException {
-		
+		if (!this.roomProviderMapService.getRoomProviderMapByUuid(roomProviderMap.getUuid()).isPresent()) {
+			throw new ObjectNotFoundException("Could not find provider's room with uuid " + roomProviderMap.getUuid());
+		}
+		this.roomProviderMapService.voidRoomProviderMap(roomProviderMap.getUuid(), voidReason);
 	}
 	
 	@Override
@@ -70,7 +73,7 @@ public class RoomProviderMapResource extends DelegatingCrudResource<RoomProvider
 	
 	@Override
 	public void purge(RoomProviderMap roomProviderMap, RequestContext requestContext) throws ResponseException {
-		
+		this.roomProviderMapService.purgeRoomProviderMap(roomProviderMap);
 	}
 	
 	@Override


### PR DESCRIPTION
This changes is an effort to cater for use cases where a single service type could be offered in more than one service point eg Same Consultation service could be offered by different clinicians sitting in different rooms. With the initial model if we used the queue table to store service points ie Queue Rooms we would be coupling patients to a specific queue because QueueEntry model has a one-to-many relationship with Queue. 
We envisioned a use case where we don't want to be coupling patients to a room/service point and to the clinician sitting in that room but instead to have clinicians be calling patients from the same Queue. With that we can quarantee we prioritise based on FIFO regardless of whether one clinician takes longer to see one patient over the others.
The management of Queues and QueueRoms will be done by the users in different facilities, therefore we couldn't use the locations table because it's a key table in reporting and we didn't want to give EMR users write access to that table.

Please review and give feedback. Regards